### PR TITLE
Potential typo

### DIFF
--- a/contracts/VirtualAugurShare.sol
+++ b/contracts/VirtualAugurShare.sol
@@ -72,7 +72,7 @@ contract VirtualAugurShare is UnlimitedAllowanceToken, Ownable {
 
   /**
    * Sets the underlying ERC-20 token of the VirtualAugurShare. Only callable by the owner when
-   * when the token is not address(0)
+   * when the token address(0)
    *
    * @param _token            Underlying ERC-20 token address to wrap
    */


### PR DESCRIPTION
The modifier checks that the token address is 0x0 (not set), yet the comments state that it checks that it IS NOT 0x0, Seems like a simple typo